### PR TITLE
rkt/core: booleans, multi-branch conds, digest, require, modulo

### DIFF
--- a/rkt/core.rkt
+++ b/rkt/core.rkt
@@ -208,6 +208,7 @@
     [`(! ,e) (we:send (rec e))]
     [`(?) (we:recv)]
     [(? number? n) (we:con n)]
+    [(? boolean? b) (we:con b)]
     [(? symbol? v) (we:var v)]
     [(cons (? operation? op) args)
      (we:app op (map rec args))]))
@@ -242,6 +243,7 @@
     [(we:var v) (list v)]
     [(we:con (? void?)) (list)]
     [(we:con (? number? n)) (list n)]
+    [(we:con (? boolean? b)) (list b)]
     [(we:app op args) (list (cons op (map we-emit1 args)))]
     [(we:if ce te fe)
      (list `(cond
@@ -453,6 +455,7 @@
     [`(?) (de:recv)]
     [`(! ,e) (de:send (rec e))]
     [(? number? n) (de:con n)]
+    [(? boolean? b) (de:con b)]
     [(? symbol? v) (de:var v)]
     [(cons (? operation? op) args)
      (de:app op (map rec args))]))
@@ -478,6 +481,7 @@
     [(de:var v) (list v)]
     [(de:con (? void?)) (list)]
     [(de:con (? number? n)) (list n)]
+    [(de:con (? boolean? b)) (list b)]
     [(de:app op args) (list (cons op (map de-emit1 args)))]
     [(de:let (== _seq_) xe be)
      (append (de-emit xe) (de-emit be))]
@@ -684,6 +688,7 @@
   (match se
     [(? symbol? v) (ha:var v)]
     [(? number? n) (ha:con n)]
+    [(? boolean? b) (ha:con b)]
     [`(void) (ha:con (void))]))
 (define (he-parse se)
   (match se
@@ -721,6 +726,7 @@
   (match ha
     [(ha:var v) v]
     [(ha:con (? number? n)) n]
+    [(ha:con (? boolean? b)) b]
     [(ha:con (? void?)) `(void)]))
 (define (he-emit he)
   (match he

--- a/rkt/core.rkt
+++ b/rkt/core.rkt
@@ -200,8 +200,13 @@
      (we:match@ at (rec e) (wm-parse m)
                 (rec `(begin ,@more)))]
     [`(begin ,e) (rec e)]
-    [`(cond [,ce ,@te] [else ,@fe])
-     (we:if (rec ce) (rec `(begin ,@te)) (rec `(begin ,@fe)))]
+    [`(begin ,(cons (? operation? op) args) ,@more)
+     (rec
+      `(begin (define ,_seq_ ,(cons op args)) ,@more))]
+    [`(cond [else ,@fe])
+     (rec `(begin ,@fe))]
+    [`(cond [,ce ,@te] ,more ..1)
+     (we:if (rec ce) (rec `(begin ,@te)) (rec `(cond ,@more)))]
     [`(if ,ce ,te ,fe)
      (we:if (rec ce) (rec te) (rec fe))]
     [`(msg ,m) (we:msg (wm-parse m))]
@@ -447,8 +452,10 @@
      (de:let x (rec xe) (rec `(begin ,@more)))]
     [`(begin ,e) (rec e)]
     [`(begin ,e ,@more) (de:seq (rec e) (rec `(begin ,@more)))]
-    [`(cond [,ce ,@te] [else ,@fe])
-     (de:if (rec ce) (rec `(begin ,@te)) (rec `(begin ,@fe)))]
+    [`(cond [else ,@fe])
+     (rec `(begin ,@fe))]
+    [`(cond [,ce ,@te] ,more ..1)
+     (de:if (rec ce) (rec `(begin ,@te)) (rec `(cond ,@more)))]
     [`(if ,ce ,te ,fe)
      (de:if (rec ce) (rec te) (rec fe))]
     [`(ignore! ,(? string? why)) (de:ignore why)]

--- a/rkt/core.rkt
+++ b/rkt/core.rkt
@@ -73,9 +73,12 @@
 (define primitive->info
   ;; XXX fill this out and make real
   (hasheq 'random (priminfo random)
+          'digest (priminfo equal-hash-code)
+          'require (priminfo (λ (b [msg "failure"]) (unless b (error msg))))
           '+ (priminfo +)
           '- (priminfo -)
           '= (priminfo =)
+          'modulo (priminfo modulo)
           'equal? (priminfo equal?)
           'msg-cat? (priminfo cons?)
           'msg-cat (priminfo cons)


### PR DESCRIPTION
This adds these to `rkt/core.rkt`:
 * boolean literals
 * multi-branch conds in the surface syntax
 * new primitives `digest`, `require`, and `modulo`