### PR TITLE
Add types for primitives in rkt/core and hs/alacrity

### DIFF
--- a/hs/alacrity/src/Alacrity/AST.hs
+++ b/hs/alacrity/src/Alacrity/AST.hs
@@ -16,8 +16,6 @@ data BaseType
 data ExprType
   = TY_Var String
   | TY_Con BaseType
-  | TY_MsgCat ExprType ExprType
-  | TY_MsgEnc ExprType
   deriving (Show,Eq)
 data FunctionType
   = TY_Arrow [ExprType] ExprType
@@ -84,12 +82,12 @@ primType (CP PGE) = [tInt, tInt] --> tBool
 primType (CP PGT) = [tInt, tInt] --> tBool
 primType (CP IF_THEN_ELSE) = TY_Forall ["a"] ([tBool, TY_Var "a", TY_Var "a"] --> TY_Var "a")
 primType (CP INT_TO_BYTES) = [tInt] --> tBytes
-primType (CP DIGEST) = TY_Forall ["a"] ([TY_Var "a"] --> tInt)
+primType (CP DIGEST) = ([tBytes] --> tInt)
 primType (CP BYTES_EQ) = [tBytes, tBytes] --> tBool
 primType (CP BYTES_LEN) = [tBytes] --> tInt
-primType (CP BCAT)       = TY_Forall ["a","b"] ([TY_Var "a", TY_Var "b"] --> TY_MsgCat (TY_Var "a") (TY_Var "b"))
-primType (CP BCAT_LEFT)  = TY_Forall ["a","b"] ([TY_MsgCat (TY_Var "a") (TY_Var "b")] --> TY_Var "a")
-primType (CP BCAT_RIGHT) = TY_Forall ["a","b"] ([TY_MsgCat (TY_Var "a") (TY_Var "b")] --> TY_Var "b")
+primType (CP BCAT)       = ([tBytes, tBytes] --> tBytes)
+primType (CP BCAT_LEFT)  = ([tBytes] --> tBytes)
+primType (CP BCAT_RIGHT) = ([tBytes] --> tBytes)
 primType (CP DISHONEST) = ([] --> tBool)
 primType RANDOM = ([] --> tInt)
 primType INTERACT = ([tBytes] --> tBytes)

--- a/hs/alacrity/src/Alacrity/AST.hs
+++ b/hs/alacrity/src/Alacrity/AST.hs
@@ -92,8 +92,7 @@ primType (CP BCAT_LEFT)  = TY_Forall ["a","b"] ([TY_MsgCat (TY_Var "a") (TY_Var 
 primType (CP BCAT_RIGHT) = TY_Forall ["a","b"] ([TY_MsgCat (TY_Var "a") (TY_Var "b")] --> TY_Var "b")
 primType (CP DISHONEST) = ([] --> tBool)
 primType RANDOM = ([] --> tInt)
--- TODO: add the type for the INTERACT primitive
-primType _ = error "XXX fill in types"
+primType INTERACT = ([tBytes] --> tBytes)
 
 type Participant = String
 

--- a/hs/alacrity/src/Alacrity/Compiler.hs
+++ b/hs/alacrity/src/Alacrity/Compiler.hs
@@ -63,7 +63,7 @@ allocANF mp e s = do
 type XLRenaming = M.Map XLVar ILArg
 type XLFuns = M.Map XLVar XLDef
 
-anf_parg :: (XLVar, AType) -> (XLRenaming, [(ILVar, AType)]) -> ANFMonad (XLRenaming, [(ILVar, AType)])
+anf_parg :: (XLVar, ExprType) -> (XLRenaming, [(ILVar, ExprType)]) -> ANFMonad (XLRenaming, [(ILVar, ExprType)])
 anf_parg (v, t) (ρ, args) =
   case M.lookup v ρ of
     Nothing -> do
@@ -73,7 +73,7 @@ anf_parg (v, t) (ρ, args) =
     Just _ -> error $ "ANF: Participant argument not bound to variable: " ++ v
   where args' nv = args ++ [(nv,t)]
 
-anf_part :: (XLRenaming, ILPartInfo) -> (Participant, [(XLVar, AType)]) -> ANFMonad (XLRenaming, ILPartInfo)
+anf_part :: (XLRenaming, ILPartInfo) -> (Participant, [(XLVar, ExprType)]) -> ANFMonad (XLRenaming, ILPartInfo)
 anf_part (ρ, ips) (p, args) = do
   (ρ', args') <- foldrM anf_parg (ρ, []) args
   let ips' = M.insert p args' ips
@@ -118,7 +118,7 @@ anf_expr σ me ρ e mk =
     XL_Consensus p msg body -> do
       anf_expr σ me ρ msg k
       where k msgas = do
-              let msgvs = vsOnly msgas 
+              let msgvs = vsOnly msgas
               (bn, bodyt) <- anf_tail σ Nothing ρ body anf_ktop
               outs <- consumeANF_N bn
               (kn, kt) <- mk $ map IL_Var outs
@@ -229,7 +229,7 @@ data SecurityLevel
   | Public
   deriving (Show)
 
-type SType = (AType, SecurityLevel)
+type SType = (ExprType, SecurityLevel)
 
 epp :: ILProgram -> BLProgram
 epp _ = error $ "XXX epp"

--- a/hs/alacrity/src/Alacrity/Parser.hs
+++ b/hs/alacrity/src/Alacrity/Parser.hs
@@ -17,10 +17,11 @@ valid_id :: String -> Bool
 valid_id p = not (elem p rsw) && head p /= '#' && (Nothing == (decodePrim p))
   where rsw = ["if", "cond", "else", "assert!", "transfer!", "declassify", "values", "@", "define", "define-values", "require"]
 
-decodeXLType :: SE.SExpr -> AType
-decodeXLType (SE.Atom "int") = AT_Int
-decodeXLType (SE.Atom "bool") = AT_Bool
-decodeXLType (SE.Atom "bytes") = AT_Bytes
+decodeXLType :: SE.SExpr -> ExprType
+decodeXLType (SE.Atom "int") = TY_Con AT_Int
+decodeXLType (SE.Atom "bool") = TY_Con AT_Bool
+decodeXLType (SE.Atom "bytes") = TY_Con AT_Bytes
+decodeXLType (SE.List [SE.Atom "Msg-Cat", l, r]) = TY_MsgCat (decodeXLType l) (decodeXLType r)
 decodeXLType se = invalid "decodeXLType" se
 
 decodeRole :: SE.SExpr -> Role
@@ -36,7 +37,7 @@ decodeXLVar (SE.Atom v)
   | otherwise = error (v ++ " is reserved!")
 decodeXLVar se = invalid "decodeXLVar" se
 
-decodeXLVarType :: SE.SExpr -> (XLVar, AType)
+decodeXLVarType :: SE.SExpr -> (XLVar, ExprType)
 decodeXLVarType (SE.List [vse,SE.Atom ":", tse]) = ((decodeXLVar vse), (decodeXLType tse))
 decodeXLVarType se = invalid "decodeXLVarType" se
 

--- a/hs/alacrity/src/Alacrity/Parser.hs
+++ b/hs/alacrity/src/Alacrity/Parser.hs
@@ -21,7 +21,6 @@ decodeXLType :: SE.SExpr -> ExprType
 decodeXLType (SE.Atom "int") = TY_Con AT_Int
 decodeXLType (SE.Atom "bool") = TY_Con AT_Bool
 decodeXLType (SE.Atom "bytes") = TY_Con AT_Bytes
-decodeXLType (SE.List [SE.Atom "Msg-Cat", l, r]) = TY_MsgCat (decodeXLType l) (decodeXLType r)
 decodeXLType se = invalid "decodeXLType" se
 
 decodeRole :: SE.SExpr -> Role


### PR DESCRIPTION
For issue https://github.com/AlacrisIO/meta/issues/7, this extends the `primitive->info` hash-table in `rkt/core` and the `primType` function is `hs/alacrity` with types for the primitives.

In both, operations such as `msg-cat`, `msg-left`, and `msg-right` have polymorphic types which use `Msg-Cat` as a pair type-constructor.

In `rkt/core`, the operations `msg-enc` and `msg-dec` have polymorphic types which use `Msg-Enc` as a wrapper type-constructor.

Also in both `digest` has the polymorphic type `∀ a. a -> Int256`. I hope that's okay since later passes of the compiler after the type-checker can make sure that a digest is computed properly, but it will need special treatment in the Solidity/EVM code generation instead of just being a single function.