### PR TITLE
js/stdlib: implement bytes_len to return the logical-length of the bytes

### DIFF
--- a/hs/alacrity/src/Alacrity/EmitJS.hs
+++ b/hs/alacrity/src/Alacrity/EmitJS.hs
@@ -93,9 +93,7 @@ jsPrimApply pr args =
     CP UINT256_TO_BYTES -> jsApply "stdlib.hexOf" args
     CP DIGEST -> jsApply "stdlib.keccak256" args
     CP BYTES_EQ -> binOp "=="
-    CP BYTES_LEN -> case args of
-                   [ a ] -> a <> pretty ".length"
-                   _ -> spa_error ()
+    CP BYTES_LEN -> jsApply "stdlib.bytes_len" args
     CP BCAT -> jsApply "stdlib.msgCons" args
     CP BCAT_LEFT -> jsApply "stdlib.msgCar" args
     CP BCAT_RIGHT -> jsApply "stdlib.msgCdr" args

--- a/js/stdlib.mjs
+++ b/js/stdlib.mjs
@@ -2,6 +2,19 @@ export function assert(cond) { XXX; }
 export function int2bytes(i) { XXX; }
 export function keccak256(b) { XXX; }
 
+export function bytes_len(b) {
+    let bh = hexOf(b);
+    // In our JS representation of byte strings, a byte
+    // is a pair of hex chars, so the "js length" is twice
+    // the "logical length". So we divide by 2 to convert
+    // js length -> logical length
+    let n = bh.length / 2;
+    if (!Number.isInteger(n)) {
+        console.error("bytes_len: byte-string has an incomplete hex-digit pair");
+    }
+    return n;
+}
+
 // Used by msg_cat to encode the left_length 16-bit unsigned integer
 // as 2 hex bytes or 4 hex characters
 function nat16_to_fixed_size_hex(n) {
@@ -24,11 +37,7 @@ function msg_left_length(msg) {
 export function msg_cat(a, b) {
     let ah = hexOf(a);
     let bh = hexOf(b);
-    // In our JS representation of byte strings, a byte
-    // is a pair of hex chars, so the "js length" is twice
-    // the "logical length". So we divide by 2 to convert
-    // js length -> logical length
-    let n = nat16_to_fixed_size_hex(ah.length / 2);
+    let n = nat16_to_fixed_size_hex(bytes_len(ah));
     return n + ah + bh;
 }
 


### PR DESCRIPTION
Our chosen JS representation of byte-strings uses a pair of hex-chars to represent a single byte. This results in the js-length being twice the logical-length. This pull request fixes that discrepancy for the `bytes_len` operation so that it returns the proper logical-length.

Are there any more places in the compiler, stdlib, or runtime where this needs to be fixed?