### PR TITLE
Made the curl testing for the starting script more accurate

### DIFF
--- a/scripts/ethereum-devnet/run.sh
+++ b/scripts/ethereum-devnet/run.sh
@@ -45,7 +45,9 @@ geth \
     --ipcpath .ethereum/geth.ipc \
     > $LOGDIR/testnet.log 2>&1 &
 
-while ! curl -sSf -X POST --data '{"jsonrpc":"2.0", "method": "web3_clientVersion", "params":[], "id":67}' http://localhost:$RPCPORT ; do
+while ! curl -sSf -X POST \
+  -H "Content-Type: application/json" \
+  --data '{"jsonrpc":"2.0", "method": "web3_clientVersion", "params":[], "id":67}' http://localhost:$RPCPORT ; do
     echo "Geth not started yet, waiting..."
     sleep 1
 done

--- a/scripts/ethereum-devnet/run.sh
+++ b/scripts/ethereum-devnet/run.sh
@@ -45,7 +45,7 @@ geth \
     --ipcpath .ethereum/geth.ipc \
     > $LOGDIR/testnet.log 2>&1 &
 
-while ! curl -sSf http://localhost:$RPCPORT ; do
+while ! curl -sSf -X POST --data '{"jsonrpc":"2.0", "method": "web3_clientVersion", "params":[], "id":67}' http://localhost:$RPCPORT ; do
     echo "Geth not started yet, waiting..."
     sleep 1
 done


### PR DESCRIPTION
Now it works with Ganache and other ethereum nodes which do not respond on `/` with a GET request.

https://github.com/trufflesuite/ganache-cli/issues/514