### PR TITLE
Ensure solidity output's timeout block depth matches JS

### DIFF
--- a/hs/alacrity/src/Alacrity/Compiler.hs
+++ b/hs/alacrity/src/Alacrity/Compiler.hs
@@ -646,7 +646,7 @@ compile copts = do
   writeFile' "bl"  blp
 
   verify_z3 (out "z3") ilp blp
-  cs <- compile_sol (out "sol") blp
+  cs <- compile_sol (out "sol") timeoutWithin blp
 
   writeFile (out "mjs") (show (emit_js timeoutWithin blp cs))
 


### PR DESCRIPTION
Thanks @MathieuDutSik for spotting the omission